### PR TITLE
Switch chokidar for watch to increase performance

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "start": "node devServer.js",
     "test": "babel-node ./test/index.js",
     "lint": "eslint source test",
-    "watch": "watch 'clear && npm run lint -s && npm run test -s' source test"
+    "watch": "chokidar 'test/**/*.js' 'source/**/*.js' --command 'clear && npm run lint -s && npm run test -s' --initial 'clear && npm run lint -s && npm run test -s'"
   },
   "repository": {
     "type": "git",
@@ -41,13 +41,13 @@
     "babel-loader": "^5.1.2",
     "babel-plugin-react-transform": "^1.1.1",
     "cheerio": "^0.19.0",
+    "chokidar-cli": "^1.1.0",
     "eslint": "^1.3.1",
     "eslint-plugin-react": "^2.3.0",
     "express": "^4.13.3",
     "redbox-react": "^1.0.1",
     "rimraf": "^2.4.3",
     "tape": "^4.2.1",
-    "watch": "^0.16.0",
     "webpack": "^1.9.6",
     "webpack-dev-middleware": "^1.2.0",
     "webpack-hot-middleware": "^2.0.0"


### PR DESCRIPTION
[Chokidar](https://github.com/paulmillr/chokidar) is much quicker than Watch. Watch still relies on `fs.watchFile`, which is less efficient. From the Node docs:

> Note: fs.watch is more efficient than fs.watchFile and fs.unwatchFile. fs.watch should be used instead of fs.watchFile and fs.unwatchFile when possible.
