### PR TITLE
Use external instance of React

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,8 @@
   <body>
     <div id='root'>
     </div>
-    <script src="/static/index.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/react/0.14.8/react.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/react/0.14.8/react-dom.min.js"></script>
+    <script src="/build/index.js"></script>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "clean": "rimraf build",
     "build:webpack": "webpack --config webpack.config.prod.js",
-    "build": "npm run clean && npm run build:webpack",
+    "build": "NODE_ENV='production' npm run clean && npm run build:webpack",
     "start": "NODE_PATH='source' node devServer.js",
     "debug": "NODE_PATH='source' echo 'Nothing? `npm install -g iron-node`' && iron-node source/debug.js",
     "lint": "eslint source",

--- a/package.json
+++ b/package.json
@@ -54,8 +54,9 @@
     "eslint-plugin-react": "4.2.3",
     "express": "4.13.4",
     "jsdom": "8.3.0",
-    "react-addons-test-utils": "0.14.8",
+    "react": "0.14.8",
     "react-dom": "0.14.8",
+    "react-addons-test-utils": "0.14.8",
     "redbox-react": "1.2.2",
     "redux": "3.3.1",
     "rimraf": "2.5.2",
@@ -65,9 +66,5 @@
     "webpack": "1.12.14",
     "webpack-dev-middleware": "1.6.1",
     "webpack-hot-middleware": "2.10.0"
-  },
-  "dependencies": {
-    "react": "0.14.8",
-    "react-dom": "0.14.3"
   }
 }

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -2,7 +2,7 @@ var path = require('path');
 var webpack = require('webpack');
 
 module.exports = {
-  devtool: 'eval',
+  devtool: 'cheap-eval-source-map',
   resolve: {
     root: __dirname + '/source'
   },
@@ -10,10 +10,14 @@ module.exports = {
     'webpack-hot-middleware/client',
     './source/index'
   ],
+  externals: {
+    'react': 'React',
+    'react-dom': 'ReactDOM'
+  },
   output: {
     path: path.join(__dirname, 'build'),
     filename: 'index.js',
-    publicPath: '/static/'
+    publicPath: '/build/'
   },
   plugins: [
     new webpack.HotModuleReplacementPlugin(),

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -9,10 +9,14 @@ module.exports = {
   entry: [
     './source/index'
   ],
+  externals: {
+    'react': 'React',
+    'react-dom': 'ReactDOM'
+  },
   output: {
     path: path.join(__dirname, 'build'),
     filename: 'index.js',
-    publicPath: '/static/'
+    publicPath: '/build/'
   },
   plugins: [
     new webpack.optimize.OccurenceOrderPlugin(),


### PR DESCRIPTION
Adds webpack configuration to externalize React modules and exclude them from the output bundle. Some tooling (enzyme, etc) still rely on `react` and `react-dom`, so they have been moved to devDependencies. Note that webpack's resolver _will still treat them as externals_ when required (imported) by a module in development, which significantly reduces build times...
#### Build Performance Summary  :rocket:
- ~**95% smaller** output bundle
- ~**70% faster** build time
##### Before

```
$ npm run build

Hash: 38045fc645a27c0d2ead
Version: webpack 1.12.14
Time: 4473ms

       Asset     Size  Chunks             Chunk Names
    index.js   139 kB       0  [emitted]  main
index.js.map  1.61 MB       0  [emitted]  main
```
##### After

```
$ npm run build

Hash: cb835d78d3e3334a27ca
Version: webpack 1.12.14
Time: 1464ms

       Asset     Size  Chunks             Chunk Names
    index.js  8.36 kB       0  [emitted]  main
index.js.map  75.6 kB       0  [emitted]  main
```
