### PR TITLE
Fix react-dom duplication in package.json and match version with react

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "express": "4.13.4",
     "jsdom": "8.4.0",
     "react-addons-test-utils": "15.0.1",
-    "react-dom": "15.0.1",
     "redbox-react": "1.2.3",
     "redux": "3.5.0",
     "rimraf": "2.5.2",
@@ -61,6 +60,6 @@
   },
   "dependencies": {
     "react": "15.0.1",
-    "react-dom": "0.14.3"
+    "react-dom": "15.0.1"
   }
 }


### PR DESCRIPTION
NPM is throwing an error when doing `npm install` because in the `package.json` file, there are 2 react-dom dependencies, one in devDependencies and the other in dependencies. It is trying to install react-dom 0.14.3, which I think was meant to be 15.0.1 to match the react dependency.
